### PR TITLE
24 jest가 svg 처리할 수 있게 추가함

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,9 @@
     // process, require, module 등 node.js 전역 변수와 api 사용할 수 있도록
     "node": true,
     // es6 문법 사용할 수 있도록
-    "es6": true
+    "es6": true,
+    // jest test framework 사용
+    "jest": true
   },
   "globals": {
     "React": "readonly"

--- a/__mocks__/svgrMock.js
+++ b/__mocks__/svgrMock.js
@@ -1,0 +1,4 @@
+module.exports = "SvgrMock"
+// named svg 파일을 ReactComponent의 형태로 대신 import 해올 때 사용하는 코드입니다.
+// import { ReactComponent as SVGName } from '/src/SVGName.svg'의 형태로 불러올 때 사용됩니다.
+// module.exports.ReactComponent = "SvgrMock"

--- a/jest.config.js
+++ b/jest.config.js
@@ -94,7 +94,9 @@ const config = {
   // ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+    "\\.svg$": "<rootDir>/__mocks__/svgrMock.js",
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^16.0.0",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+        "@types/jest": "^29.5.12",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -3841,6 +3842,48 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
     },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+    "@types/jest": "^29.5.12",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/types/common/global.d.ts
+++ b/src/types/common/global.d.ts
@@ -3,4 +3,7 @@ declare module "*.svg" {
 
   const svg: React.FC<React.SVGProps<SVGSVGElement>>
   export default svg
+  // named svg 파일을 ReactComponent의 형태로 대신 import 해올 때 사용하는 코드입니다.
+  // import { ReactComponent as SVGName } from '/src/SVGName.svg'의 형태로 불러올 때 사용됩니다.
+  // export const ReactComponent: React.VFC<React.SVGProps<SVGSVGElement>>
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,14 @@
     },
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/types/**/*.d.ts", "next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next.config.mjs",
+    "src/types/**/*.d.ts",
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "__mocks__/svgrMock.js"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #24

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- [x] jest에서 svg를 인식할 수 있게 수정함
- [x] jest를 ts파일에서 사용할 수 있게 @type.jest를 설치함
- [x] jest를 ESLint에서 인식할 수 있게 추가함


## 작업 내용 설명

1. Jest의 SVG 처리 문제:
    - Jest는 기본적으로 JavaScript 테스트 러너이기 때문에 SVG 파일을 직접 이해하거나 처리할 수 없습니다.
    - React 컴포넌트에서 SVG를 import하여 사용할 때, Jest는 이를 객체로 인식하여 "type is invalid" 오류를 발생시킵니다.
2. 해결 방법:a) SVG 모킹(Mocking):b) SVG 변환(Transformation):
    - Jest가 SVG 파일을 만났을 때 이를 대체할 모의 객체를 생성합니다.
    - 이 방법은 SVG의 실제 내용은 무시하고 단순히 컴포넌트가 렌더링 되는지만 확인합니다.
    - SVG 파일을 Jest가 이해할 수 있는 형태로 변환합니다.
    - 이 방법은 SVG의 내용을 유지하면서 테스트할 수 있게 해줍니다.
3. 구체적인 설정 방법:a) 모킹 방식:b) 변환 방식:
    - **__mocks**__/svgrMock.js 파일 생성:
        
        ```jsx
        module.exports = "SvgrMock"
        // named svg 파일을 ReactComponent의 형태로 대신 import 해올 때 사용하는 코드입니다.
        // import { ReactComponent as SVGName } from '/src/SVGName.svg'의 형태로 불러올 때 사용됩니다.
        // module.exports.ReactComponent = "SvgrMock"
        
        ```
        
    - typescript.config.js
        
        ```jsx
        "include": [
            "next.config.mjs",
            "src/types/**/*.d.ts",
            "next-env.d.ts",
            "**/*.ts",
            "**/*.tsx",
            ".next/types/**/*.ts",
            // svgrMock.js 추가
            "__mocks__/svgrMock.js"
          ],
        ```
        
    - jest.config.js - svgrMock.js 파일을 감지하게 함
        
        ```jsx
        moduleNameMapper: {
            "\\.svg$": "<rootDir>/__mocks__/svgrMock.js",
          },
        ```
        
    - global.d.ts - 이름은 상관없음
        
        ```jsx
        declare module "*.svg" {
          import React from "react"
        
          const svg: React.FC<React.SVGProps<SVGSVGElement>>
          export default svg
          // named svg 파일을 ReactComponent의 형태로 대신 import 해올 때 사용하는 코드입니다.
          // import { ReactComponent as SVGName } from '/src/SVGName.svg'의 형태로 불러올 때 사용됩니다.
          // export const ReactComponent: React.VFC<React.SVGProps<SVGSVGElement>>
        }
        
        ```
        
4. 사용 방법
    
    테스트 코드 예시
    
    ```bash
    import React from "react"
    
    // svgr/webpack을 통해 svg가 reactcomponent로 불러와진다.
    // svgr/webpack을 사용하지 않는다면 위에서 주석처리 한 부분을 활성화하고 아래의 형태로 사용해야 한다.
    // import { ReactComponent as Alarm } from '/src/Alarm' 
    import Alarm from "@public/ic/Alarm"
    import "@testing-library/jest-dom"
    import { render } from "@testing-library/react"
    
    // jest에서 svg를 인식할 수 있도록 svg를 별도로 모킹을 해준다.
    jest.mock("@/public/icon/alarm.svg", () => {
      return "SvgrMock"
    })
    
    describe("Alarm 컴포넌트", () => {
      test("Alarm SVG가 렌더링되는지 검증합니다", () => {
        expect(render(<Alarm className="test-class" />)).not.toBeNull()
      })
    
      test("SVG 요소가 존재하는지 검증합니다", () => {
    	  // svg를 검증하는 부분.
        const { container } = render(<Alarm className="test-class" />)
        const svgElement = container.querySelector("svgrmock")
        expect(svgElement).toBeInTheDocument()
      })
    
      test("올바른 클래스 이름으로 렌더링 되는지 확인합니다", () => {
        const { container } = render(<Alarm className="test-class" />)
        const svgElement = container.querySelector("svgrmock")
        expect(svgElement).toHaveClass("test-class w-6 h-6 text-[#FFFFFF]")
      })
    
      test("SVG 요소가 div 안에 있는지 검증합니다", () => {
        const { container } = render(<Alarm className="test-class" />)
        const svgElement = container.querySelector("svgrmock")
        expect(svgElement?.parentElement?.tagName).toBe("DIV")
      })
    })
    
    ```
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
