### PR TITLE
feat : 없는 주소로 가면 not-found 로 이동

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link"
+
+const notFound = () => {
+  return (
+    <div className="flex h-screen flex-col items-center justify-center">
+      <h2 className="text-5xl font-bold text-orange-600">404</h2>
+      <p className="mt-2 text-xl font-medium">잘못된 페이지 접근 입니다.</p>
+      <Link
+        href="/"
+        className="mt-4 rounded-xl border border-orange-600 px-4 py-2 text-sm font-medium text-orange-600 transition-colors hover:bg-orange-600 hover:text-white"
+      >
+        메인으로 돌아가기
+      </Link>
+    </div>
+  )
+}
+
+export default notFound


### PR DESCRIPTION
## #️⃣연관된 이슈

> #26 

## 📝작업 내용

> 없는 주소로 이동시 Not-Found로 가게 설정했습니다.
뒤로가기 버튼은 따로 안만들고 홈 화면으로 이동하게끔 설정했습니다.

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/1270fbd4-af7d-4519-abe4-ecc1455ba903)
