### PR TITLE
#47 리액트와 타입스크립트 버전을 업데이트 합니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "dayjs": "^1.11.12",
         "msw": "^2.3.4",
         "next": "14.2.5",
-        "react": "^18",
+        "react": "^18.3.1",
         "react-calendar": "^5.0.0",
         "react-dom": "^18"
       },
@@ -46,7 +46,7 @@
         "prettier-plugin-tailwindcss": "^0.6.5",
         "sass": "^1.77.8",
         "tailwindcss": "^3.4.1",
-        "typescript": "^4.7.4"
+        "typescript": "5.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -11772,16 +11772,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dayjs": "^1.11.12",
     "msw": "^2.3.4",
     "next": "14.2.5",
-    "react": "^18",
+    "react": "^18.3.1",
     "react-calendar": "^5.0.0",
     "react-dom": "^18"
   },
@@ -48,6 +48,6 @@
     "prettier-plugin-tailwindcss": "^0.6.5",
     "sass": "^1.77.8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^4.7.4"
+    "typescript": "5.4"
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #47 

## 📝작업 내용

> Next.js에서 지원하는 async server component 와 eslint의 빌드 오류 때문에 버전을 업데이트해서 오류를 수정합니다.

> "react": "^18.3.1", "typescript": "5.4"