### PR TITLE
#80 로그인, 회원가입 페이지 test 코드 작성 완료

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -96,6 +96,7 @@ const config = {
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   moduleNameMapper: {
     "\\.svg$": "<rootDir>/__mocks__/svgrMock.jsx",
+    "^@/(.*)$": "<rootDir>/src/$1",
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/src/actions/api-actions/Auths.ts
+++ b/src/actions/api-actions/Auths.ts
@@ -9,7 +9,7 @@ interface SignupData {
 
 // 사용자 회원가입
 const PostSignupFn = async (signupData: SignupData) => {
-  const response = await fetch(`${process.env.BASE_URL}/auths/signup`, {
+  const response = await fetch(`${process.env.BASE_URL}/${process.env.TEAM_ID}/auths/signup`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -32,7 +32,7 @@ interface SigninData {
 
 // 사용자 로그인
 const PostSigninFn = async (signinData: SigninData) => {
-  const response = await fetch(`${process.env.BASE_URL}/auths/signin`, {
+  const response = await fetch(`${process.env.BASE_URL}/${process.env.TEAM_ID}/auths/signin`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -50,7 +50,7 @@ const PostSigninFn = async (signinData: SigninData) => {
 
 // 회원 정보 확인
 const GetUserDataFn = async (userToken?: string) => {
-  const response = await fetch(`${process.env.BASE_URL}/auths/user`, {
+  const response = await fetch(`${process.env.BASE_URL}/${process.env.TEAM_ID}/auths/user`, {
     headers: {
       Authorization: `Bearer ${userToken}`,
     },
@@ -66,7 +66,7 @@ const GetUserDataFn = async (userToken?: string) => {
 
 // 사용자 로그아웃
 const PostLogoutFn = async () => {
-  const response = await fetch(`${process.env.BASE_URL}/auths/user`)
+  const response = await fetch(`${process.env.BASE_URL}/${process.env.TEAM_ID}/auths/user`)
 
   const data = await response.json()
 

--- a/src/app/auth/@signin/SigninForm.test.tsx
+++ b/src/app/auth/@signin/SigninForm.test.tsx
@@ -1,0 +1,156 @@
+import { useRouter } from "next/navigation"
+
+import React from "react"
+
+import { usePostSignin } from "@/actions/api-hooks/Auths"
+import "@testing-library/jest-dom"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+
+import SigninForm from "./SigninForm"
+
+// useRouter와 usePostSignin 훅 모킹
+jest.mock("next/navigation", () => {
+  return {
+    useRouter: jest.fn(),
+  }
+})
+
+jest.mock("@/actions/api-hooks/Auths", () => {
+  return {
+    usePostSignin: jest.fn(() => {
+      jest.fn((data, options) => {
+        if (options && options.onSuccess) {
+          options.onSuccess()
+        }
+      })
+    }),
+    error: null,
+  }
+})
+
+// svg 모킹
+jest.mock("@/components/public/icon/staticIcon/VisibilityOff", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return <svg data-testid="visibility-off-icon" />
+    },
+  }
+})
+
+jest.mock("@/components/public/icon/staticIcon/VisibilityOn", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return <svg data-testid="visibility-on-icon" />
+    },
+  }
+})
+
+// InputField 모킹
+jest.mock("@/components/public/input/InputField", () => {
+  return jest.fn(({ label, name, type, placeholder, register }) => {
+    return (
+      <div>
+        <label htmlFor={name}>{label}</label>
+        <input
+          type={type}
+          name={name}
+          placeholder={placeholder}
+          data-testid={`mocked-input-${name}`}
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...(register && register(name))}
+        />
+      </div>
+    )
+  })
+})
+
+// Button 모킹
+jest.mock("@/components/public/button/Button", () => {
+  return jest.fn(({ children, disabled }) => {
+    return (
+      <button type="submit" disabled={disabled}>
+        {children}
+      </button>
+    )
+  })
+})
+
+describe("SigninForm", () => {
+  const mockRouter = {
+    replace: jest.fn(),
+  }
+  const mockSignin = jest.fn()
+
+  beforeEach(() => {
+    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+    ;(usePostSignin as jest.Mock).mockReturnValue({
+      mutate: mockSignin,
+      error: null,
+    })
+  })
+
+  it("기본 렌더링 테스트", () => {
+    render(<SigninForm />)
+
+    expect(screen.getByText("로그인")).toBeInTheDocument()
+    expect(screen.getByText("아이디")).toBeInTheDocument()
+    expect(screen.getByText("비밀번호")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "확인" })).toBeInTheDocument()
+    expect(screen.getByText("회원가입")).toBeInTheDocument()
+  })
+
+  it("폼이 비어있을 때 버튼 비활성화 유무 테스트", () => {
+    render(<SigninForm />)
+
+    const submitButton = screen.getByRole("button", { name: "확인" })
+    expect(submitButton).toBeDisabled()
+  })
+
+  it("폼이 채워지면 버튼 활성화 유무 테스트", async () => {
+    render(<SigninForm />)
+
+    const emailInput = screen.getByTestId("mocked-input-email")
+    const passwordInput = screen.getByTestId("mocked-input-password")
+    const submitButton = screen.getByRole("button", { name: "확인" })
+
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } })
+    fireEvent.change(passwordInput, { target: { value: "password123" } })
+
+    await waitFor(() => {
+      expect(submitButton).not.toBeDisabled()
+    })
+  })
+
+  it("signin 함수 호출 및 응답 성공 테스트", async () => {
+    render(<SigninForm />)
+
+    const emailInput = screen.getByTestId("mocked-input-email")
+    const passwordInput = screen.getByTestId("mocked-input-password")
+    const submitButton = screen.getByRole("button", { name: "확인" })
+
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } })
+    fireEvent.change(passwordInput, { target: { value: "password123" } })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockSignin).toHaveBeenCalledWith(
+        { email: "test@example.com", password: "password123" },
+        expect.any(Object),
+      )
+    })
+  })
+
+  it("실패 에러 메시지 표시 유무 테스트", async () => {
+    const errorMessage = "로그인에 실패했습니다."
+    ;(usePostSignin as jest.Mock).mockReturnValue({
+      mutate: mockSignin,
+      error: { message: errorMessage },
+    })
+
+    render(<SigninForm />)
+
+    expect(screen.getByText(`※ ${errorMessage}`)).toBeInTheDocument()
+  })
+})

--- a/src/app/auth/@signin/SigninForm.tsx
+++ b/src/app/auth/@signin/SigninForm.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 
-import { useEffect, useState } from "react"
+import { Fragment, useEffect, useState } from "react"
 import { SubmitHandler, useForm } from "react-hook-form"
 
 import { usePostSignin } from "@/actions/api-hooks/Auths"
@@ -88,7 +88,7 @@ const SigninForm = () => {
         <span className="text-center text-gray-800">로그인</span>
         {signinFormValue.map((value) => {
           return (
-            <div key={value.label}>
+            <Fragment key={value.label}>
               <InputField
                 label={value.label}
                 name={value.name}
@@ -103,7 +103,7 @@ const SigninForm = () => {
                 inputType="input"
                 size="large"
               />
-            </div>
+            </Fragment>
           )
         })}
         {signinError && <span>※ {signinError.message}</span>}

--- a/src/app/auth/@signup/SignupForm.test.tsx
+++ b/src/app/auth/@signup/SignupForm.test.tsx
@@ -1,0 +1,176 @@
+import { useRouter } from "next/navigation"
+
+import React from "react"
+
+import { usePostSignup } from "@/actions/api-hooks/Auths"
+import "@testing-library/jest-dom"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+
+import SignupForm from "./SignupForm"
+
+// useRouter와 usePostSignup 훅 모킹
+jest.mock("next/navigation", () => {
+  return {
+    useRouter: jest.fn(),
+  }
+})
+
+jest.mock("@/actions/api-hooks/Auths", () => {
+  return {
+    usePostSignup: jest.fn(() => {
+      jest.fn((data, options) => {
+        if (options && options.onSuccess) {
+          options.onSuccess()
+        }
+      })
+    }),
+    error: null,
+  }
+})
+
+// svg 모킹
+jest.mock("@/components/public/icon/staticIcon/VisibilityOff", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return <svg data-testid="visibility-off-icon" />
+    },
+  }
+})
+
+jest.mock("@/components/public/icon/staticIcon/VisibilityOn", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return <svg data-testid="visibility-on-icon" />
+    },
+  }
+})
+
+// InputField 모킹
+jest.mock("@/components/public/input/InputField", () => {
+  return jest.fn(({ label, name, type, placeholder, register }) => {
+    return (
+      <div>
+        <label htmlFor={name}>{label}</label>
+        <input
+          type={type}
+          name={name}
+          placeholder={placeholder}
+          data-testid={`mocked-input-${name}`}
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...(register && register(name))}
+        />
+      </div>
+    )
+  })
+})
+
+// Button 모킹
+jest.mock("@/components/public/button/Button", () => {
+  return jest.fn(({ children, disabled }) => {
+    return (
+      <button type="submit" disabled={disabled}>
+        {children}
+      </button>
+    )
+  })
+})
+
+describe("SignupForm", () => {
+  const mockRouter = {
+    replace: jest.fn(),
+  }
+  const mockSignup = jest.fn()
+
+  beforeEach(() => {
+    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+    ;(usePostSignup as jest.Mock).mockReturnValue({
+      mutate: mockSignup,
+      error: null,
+    })
+  })
+
+  it("기본 렌더링 테스트", () => {
+    render(<SignupForm />)
+
+    expect(screen.getByText("회원가입")).toBeInTheDocument()
+    expect(screen.getByText("이름")).toBeInTheDocument()
+    expect(screen.getByText("아이디")).toBeInTheDocument()
+    expect(screen.getByText("회사명")).toBeInTheDocument()
+    expect(screen.getByText("비밀번호")).toBeInTheDocument()
+    expect(screen.getByText("비밀번호 확인")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "확인" })).toBeInTheDocument()
+    expect(screen.getByText("로그인")).toBeInTheDocument()
+  })
+
+  it("폼이 비어있을 때 버튼 비활성화 유무 테스트", () => {
+    render(<SignupForm />)
+
+    const submitButton = screen.getByRole("button", { name: "확인" })
+    expect(submitButton).toBeDisabled()
+  })
+
+  it("폼이 채워지면 버튼 활성화 유무 테스트", async () => {
+    render(<SignupForm />)
+
+    const nameInput = screen.getByTestId("mocked-input-name")
+    const emailInput = screen.getByTestId("mocked-input-email")
+    const companyNameInput = screen.getByTestId("mocked-input-companyName")
+    const passwordInput = screen.getByTestId("mocked-input-password")
+    const passwordConfirmInput = screen.getByTestId("mocked-input-passwordConfirm")
+    const submitButton = screen.getByRole("button", { name: "확인" })
+
+    fireEvent.change(nameInput, { target: { value: "김창민" } })
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } })
+    fireEvent.change(companyNameInput, { target: { value: "CODEIT" } })
+    fireEvent.change(passwordInput, { target: { value: "password123" } })
+    fireEvent.change(passwordConfirmInput, { target: { value: "password123" } })
+
+    await waitFor(() => {
+      expect(submitButton).not.toBeDisabled()
+    })
+  })
+
+  it("signin 함수 호출 및 응답 성공 테스트", async () => {
+    render(<SignupForm />)
+
+    const nameInput = screen.getByTestId("mocked-input-name")
+    const emailInput = screen.getByTestId("mocked-input-email")
+    const companyNameInput = screen.getByTestId("mocked-input-companyName")
+    const passwordInput = screen.getByTestId("mocked-input-password")
+    const passwordConfirmInput = screen.getByTestId("mocked-input-passwordConfirm")
+    const submitButton = screen.getByRole("button", { name: "확인" })
+
+    fireEvent.change(nameInput, { target: { value: "김창민" } })
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } })
+    fireEvent.change(companyNameInput, { target: { value: "CODEIT" } })
+    fireEvent.change(passwordInput, { target: { value: "password123" } })
+    fireEvent.change(passwordConfirmInput, { target: { value: "password123" } })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockSignup).toHaveBeenCalledWith(
+        {
+          email: "test@example.com",
+          password: "password123",
+          name: "김창민",
+          companyName: "CODEIT",
+        },
+        expect.any(Object),
+      )
+    })
+  })
+
+  it("실패 에러 메시지 표시 유무 테스트", async () => {
+    const errorMessage = "로그인에 실패했습니다."
+    ;(usePostSignup as jest.Mock).mockReturnValue({
+      mutate: mockSignup,
+      error: { message: errorMessage },
+    })
+
+    render(<SignupForm />)
+
+    expect(screen.getByText(`※ ${errorMessage}`)).toBeInTheDocument()
+  })
+})

--- a/src/app/auth/@signup/SignupForm.tsx
+++ b/src/app/auth/@signup/SignupForm.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 
-import { useEffect, useState } from "react"
+import { Fragment, useEffect, useState } from "react"
 import { SubmitHandler, useForm } from "react-hook-form"
 
 import { usePostSignup } from "@/actions/api-hooks/Auths"
@@ -117,7 +117,7 @@ const SignupForm = () => {
         <span className="text-center text-gray-800">회원가입</span>
         {signupFormValue.map((value) => {
           return (
-            <div key={value.label}>
+            <Fragment key={value.label}>
               <InputField
                 label={value.label}
                 name={value.name}
@@ -132,7 +132,7 @@ const SignupForm = () => {
                 inputType="input"
                 size="large"
               />
-            </div>
+            </Fragment>
           )
         })}
         {signupError && <span>※ {signupError.message}</span>}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #80

## 📝작업 내용

> - [x] 불필요하게 반복되는 div 요소를 dom에서 제거하기 위해 map의 div를 Fragment 태그로 변경함
> - [x] 기존에 완성되었던 로그인, 회원가입 페이지의 테스트 코드를 작성함
> - [x] jest가 @/를 통한 경로를 인식할 수 있도록 jest 파일을 수정함




### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 테스트 코드에서 추가로 검증하면 좋은 부분이 있을까요? 일단 페이지 이동 관련 테스트는 미들웨어에서 처리하도록 바뀔수도 있을 것 같아서 뺀 상태입니다.
