### PR TITLE
#107 마이페이지 무한 스크롤 구현

### DIFF
--- a/src/app/(myPage)/mypage/layout.tsx
+++ b/src/app/(myPage)/mypage/layout.tsx
@@ -8,8 +8,10 @@ interface IMyPageLayoutProps {
 
 const MyPageLayout = ({ edit, addReview, children }: IMyPageLayoutProps) => {
   return (
-    <div className="mx-auto h-screen max-w-[1200px] bg-gray-50 px-[16px] md:px-[24px] lg:px-[97px]">
-      <h2 className="mx-auto mb-6 w-full pl-1 pt-8 text-2xl font-semibold">마이페이지</h2>
+    <div className="relative mx-auto h-screen max-w-[1200px] bg-gray-50 px-[16px] md:px-[24px] lg:px-[97px]">
+      <h2 className="z-1 absolute left-0 right-0 top-4 mx-auto w-full pl-24 pt-8 text-2xl font-semibold">
+        마이페이지
+      </h2>
       {children}
       {edit}
       {addReview}

--- a/src/app/(myPage)/mypage/page.tsx
+++ b/src/app/(myPage)/mypage/page.tsx
@@ -13,7 +13,7 @@ const MyPage = async () => {
   })
 
   return (
-    <main>
+    <main className="flex h-full flex-col items-stretch gap-3 pt-28">
       <ProfileBox />
       <HydrationBoundary state={dehydrate(queryClient)}>
         <MyPageInfoTap />

--- a/src/components/pages/mypage/MyPageInfoTap.tsx
+++ b/src/components/pages/mypage/MyPageInfoTap.tsx
@@ -67,7 +67,7 @@ const MyPageInfoTap = () => {
   })
 
   return (
-    <section className="mx-auto mt-[29px] h-[730px] overflow-hidden border-t-2 border-gray-900 bg-white p-6">
+    <section className="mx-auto mt-[29px] w-full grow overflow-y-scroll border-t-2 border-gray-900 bg-white p-6">
       <div className="mb-6 flex gap-3">
         <MyPageInfoTapButton onClick={dispatch} state="myMeeting" isActive={tapState.myMeeting} />
         <MyPageInfoTapButton onClick={dispatch} state="myReview" isActive={tapState.myReview} />

--- a/src/components/pages/mypage/MyPageInfoWrapper.tsx
+++ b/src/components/pages/mypage/MyPageInfoWrapper.tsx
@@ -3,13 +3,14 @@
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 
-import { MouseEvent, useState } from "react"
+import { MouseEvent, useCallback, useEffect, useState } from "react"
+import { useInView } from "react-intersection-observer"
 
 import { IGetMyPageRes, IReview, fetchMyPageInfo } from "@/actions/fetchMyPageInfo"
 import Card from "@/components/public/Card/Card"
 import Review from "@/components/public/Review/Review"
 import Spinner from "@/components/public/Spinner/Spinner"
-import { useQuery } from "@tanstack/react-query"
+import { useInfiniteQuery } from "@tanstack/react-query"
 
 import ReviewStateButton from "./ReviewStateButton"
 
@@ -30,6 +31,9 @@ const MyPageInfoWrapper = ({ dataFetchingKey, onClick, reviewed }: IMyPageInfoWr
   const initialState = reviewed && true
   const router = useRouter()
   const [hasReview, setHasReview] = useState(initialState)
+  const { ref, inView } = useInView({
+    threshold: 1,
+  })
 
   let dataSort: IDataSort = { dataFetchingKey }
 
@@ -37,17 +41,25 @@ const MyPageInfoWrapper = ({ dataFetchingKey, onClick, reviewed }: IMyPageInfoWr
     dataSort = { ...dataSort, isReviewed: true }
   }
 
-  const { data, isPending } = useQuery({
+  const { data, isPending, fetchNextPage } = useInfiniteQuery({
     queryKey: ["mypage", dataSort],
-    queryFn: ({ queryKey }) => {
+    queryFn: ({ queryKey, pageParam }) => {
       const querySort = queryKey[1] as IDataSort
       const fetchingKey = querySort.dataFetchingKey
       const isReviewed = querySort.isReviewed ?? null
-      const offset = 0
+      const offset = pageParam
       const limit = 5
       return fetchMyPageInfo({ fetchingKey, offset, limit, isReviewed })
     },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages, lastPageParam) => {
+      return lastPage.hasMore ? lastPageParam + 5 : undefined
+    },
   })
+
+  const fetchNextPageCallback = useCallback(() => {
+    return fetchNextPage
+  }, [fetchNextPage])
 
   const reviewButtonHandler = () => {
     setHasReview(!hasReview)
@@ -58,54 +70,63 @@ const MyPageInfoWrapper = ({ dataFetchingKey, onClick, reviewed }: IMyPageInfoWr
     onClick({ type: "myReview", reviewed: true })
     setHasReview(true)
   }
+
   const clickCreateReviewHandler = (e: MouseEvent, pathId: number) => {
     e.preventDefault()
     router.push(`/mypage/addReview?gatheringId=${pathId}`)
   }
 
-  if (isPending) return <Spinner />
+  useEffect(() => {
+    fetchNextPageCallback()
+  }, [inView, fetchNextPageCallback])
 
+  const dataPages = data?.pages ?? []
+
+  if (isPending) return <Spinner />
   return (
     <>
       {isMyReview && <ReviewStateButton onClick={reviewButtonHandler} hasReview={hasReview} />}
-      <div className="flex flex-col gap-6">
-        {data &&
-          data.map((item: IGetMyPageRes & IReview) => {
-            if (isMyReview && hasReview) {
+      <div className="relative flex flex-col gap-6 overflow-hidden">
+        {dataPages &&
+          dataPages.map((dataPage) => {
+            return dataPage.data.map((item: IGetMyPageRes & IReview) => {
+              if (isMyReview && hasReview) {
+                return (
+                  <Review
+                    key={item.id}
+                    score={item.score}
+                    createdAt={item.createdAt}
+                    comment={item.comment}
+                    gathering={item.Gathering}
+                    isImage={item.Gathering.image !== ""}
+                  />
+                )
+              }
               return (
-                <Review
-                  key={item.id}
-                  score={item.score}
-                  createdAt={item.createdAt}
-                  comment={item.comment}
-                  gathering={item.Gathering}
-                  isImage={item.Gathering.image !== ""}
-                />
+                <Link key={item.name} href={`/findMeeting/${item.id}`}>
+                  <Card
+                    handlerReview={(e: MouseEvent) => {
+                      clickCreateReviewHandler(e, item.id)
+                    }}
+                    handlerView={clickViewReviewHandler}
+                    teamId={item.teamId}
+                    id={item.id}
+                    name={item.name}
+                    dateTime={item.dateTime}
+                    registrationEnd={item.registrationEnd}
+                    location={item.location}
+                    participantCount={item.participantCount}
+                    image={item.image}
+                    capacity={item.capacity}
+                    isBtnHide={isMyOwnMeeting}
+                    isMy={isMyOwnMeeting || !hasReview}
+                    isReview={item.isReviewed}
+                  />
+                </Link>
               )
-            }
-            return (
-              <Link key={item.name} href={`/findMeeting/${item.id}`}>
-                <Card
-                  handlerReview={(e: MouseEvent) => {
-                    clickCreateReviewHandler(e, item.id)
-                  }}
-                  handlerView={clickViewReviewHandler}
-                  teamId={item.teamId}
-                  id={item.id}
-                  name={item.name}
-                  dateTime={item.dateTime}
-                  registrationEnd={item.registrationEnd}
-                  location={item.location}
-                  participantCount={item.participantCount}
-                  image={item.image}
-                  capacity={item.capacity}
-                  isBtnHide={isMyOwnMeeting}
-                  isMy={isMyOwnMeeting || !hasReview}
-                  isReview={item.isReviewed}
-                />
-              </Link>
-            )
+            })
           })}
+        <div ref={ref} className="h-1 w-full" />
       </div>
     </>
   )

--- a/src/components/pages/mypage/MyPageInfoWrapper.tsx
+++ b/src/components/pages/mypage/MyPageInfoWrapper.tsx
@@ -25,6 +25,26 @@ interface IDataSort {
   isReviewed?: boolean
 }
 
+const useInfiniteQueryHook = (keyData: IDataSort) => {
+  const { data, isPending, fetchNextPage } = useInfiniteQuery({
+    queryKey: ["mypage", keyData],
+    queryFn: ({ queryKey, pageParam }) => {
+      const querySort = queryKey[1] as IDataSort
+      const fetchingKey = querySort.dataFetchingKey
+      const isReviewed = querySort.isReviewed ?? null
+      const offset = pageParam
+      const limit = 5
+      return fetchMyPageInfo({ fetchingKey, offset, limit, isReviewed })
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages, lastPageParam) => {
+      return lastPage.hasMore ? lastPageParam + 5 : undefined
+    },
+  })
+
+  return { data, isPending, fetchNextPage }
+}
+
 const MyPageInfoWrapper = ({ dataFetchingKey, onClick, reviewed }: IMyPageInfoWrapperProps) => {
   const isMyOwnMeeting = dataFetchingKey === "myOwnMeeting"
   const isMyReview = dataFetchingKey === "myReview"
@@ -41,21 +61,7 @@ const MyPageInfoWrapper = ({ dataFetchingKey, onClick, reviewed }: IMyPageInfoWr
     dataSort = { ...dataSort, isReviewed: true }
   }
 
-  const { data, isPending, fetchNextPage } = useInfiniteQuery({
-    queryKey: ["mypage", dataSort],
-    queryFn: ({ queryKey, pageParam }) => {
-      const querySort = queryKey[1] as IDataSort
-      const fetchingKey = querySort.dataFetchingKey
-      const isReviewed = querySort.isReviewed ?? null
-      const offset = pageParam
-      const limit = 5
-      return fetchMyPageInfo({ fetchingKey, offset, limit, isReviewed })
-    },
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, allPages, lastPageParam) => {
-      return lastPage.hasMore ? lastPageParam + 5 : undefined
-    },
-  })
+  const { data, isPending, fetchNextPage } = useInfiniteQueryHook(dataSort)
 
   const fetchNextPageCallback = useCallback(() => {
     return fetchNextPage

--- a/src/components/public/ProfileBox.tsx
+++ b/src/components/public/ProfileBox.tsx
@@ -9,7 +9,7 @@ const ProfileBox = async () => {
   const userInfo = await getUserInfo()
 
   return (
-    <div className="relative mx-auto h-44 w-full rounded-3xl border-2 border-gray-200 bg-white">
+    <div className="relative mx-auto h-[172px] w-full flex-none rounded-3xl border-2 border-gray-200 bg-white">
       <div className="flex items-center justify-between rounded-t-3xl bg-orange-400 px-6 pb-5 pt-3.5">
         <h3 className="text-lg font-semibold">내 프로필</h3>
         <ProfileEditBtn />


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #107 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- useInVue로 intersection observer 대체
- useInfiniteQuery로 무한 스크롤 구현
- offset을 nextPageParam으로 수정
- 현재 limit 5, offset 5씩 증가 -> production 시 10으로 수정 예정


### 스크린샷 (선택)

![무한스크롤 테스트](https://github.com/user-attachments/assets/3a689fc0-c722-473e-b502-bcce9d67a51c)


- 글들이 충분히 생성되어 있지 않아 test용 div 생성해서 만들어 테스트 했습니다.
- 이후 test div는 모두 삭제했습니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- useEffect를 통해서 useInView와 연결된 domNode가 노출되는 상황을 감시하고 있습니다.
- 그리고 해당 요소가 보일 경우 fetchNextPage()함수를 실행해 다음 값을 로드하고 있습니다.
- 문제는 useEffect내에서 fetchNextPage()를 dependency에 추가하길 요구하고 있으나 함수로 일급 객체이기에 무한 렌더링 발생이 있어 useCallBack을 사용해서 같은 값이라는 것을 명시해뒀습니다.
