### PR TITLE
#149 auth 디테일 수정 및 jest, cypress lint 충돌 문제 해결

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,8 +12,26 @@
     "prettier",
     "plugin:cypress/recommended"
   ],
+  "overrides": [
+    {
+      "files": ["**/*.ts", "**/*.tsx"],
+      "excludedFiles": ["cypress/**/*.ts", "cypress/**/*.tsx"],
+      "parserOptions": {
+        "project": "./tsconfig.json"
+      }
+    },
+    {
+      "files": ["cypress/**/*.ts", "cypress/**/*.tsx"],
+      "parserOptions": {
+        "project": "./cypress/tsconfig.json"
+      },
+      "rules": {
+        // Cypress 파일에 대한 특별한 ESLint 규칙을 여기에 추가할 수 있습니다.
+      }
+    }
+  ],
   "parserOptions": {
-    "project": "./tsconfig.json"
+    "project": ["./tsconfig.json", "./cypress/tsconfig.json"]
   },
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "prettier"],

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["cypress"],
+    "isolatedModules": false
+  },
+  "include": ["../node_modules/cypress", "./**/*.ts", "./**/*.tsx"],
+  "exclude": ["../node_modules"]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -168,9 +168,8 @@ const config = {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "\\\\node_modules\\\\"
-  // ],
+
+  testPathIgnorePatterns: ["<rootDir>/cypress/"],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],

--- a/src/app/auth/AuthLayout.tsx
+++ b/src/app/auth/AuthLayout.tsx
@@ -5,7 +5,7 @@ const authLayoutStyles = {
     default: "w-full bg-slate-100",
     mobile: "min-h-[906px] pt-[33px] pb-[72px]",
     tablet: "md:min-h-[1133px] md:pt-10 md:pb-[162px]",
-    desktop: "2xl:min-h-[1080px] 2xl:py-[329px]",
+    desktop: "2xl:min-h-[1080px] 2xl:py-[153px]",
   },
   wrapper: {
     default: "flex flex-col items-center justify-center",

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useSearchParams } from "next/navigation"
+import { notFound, useSearchParams } from "next/navigation"
 
 import AuthLayoutComponent from "./AuthLayout"
 
@@ -8,9 +8,17 @@ const AuthLayout = ({ signin, signup }: { signin: React.ReactNode; signup: React
   const searchParams = useSearchParams()
   const mode = searchParams.get("mode")
 
+  // mode 쿼리스트링이 로그인, 회원가입 페이지 모두와 일치하지 않을 경우 에러 페이지로 이동
+  if (!mode || (mode !== "signin" && mode !== "signup")) {
+    notFound()
+  }
+
+  // mode 쿼리스트링에 따라 로그인, 회원가입 페이지의 내용을 결정
+  const content = mode === "signup" ? signup : signin
+
   return (
     <div>
-      <AuthLayoutComponent>{mode === "signin" ? signin : signup}</AuthLayoutComponent>
+      <AuthLayoutComponent>{content}</AuthLayoutComponent>
     </div>
   )
 }

--- a/src/components/pages/auth/@signin/SigninForm.tsx
+++ b/src/components/pages/auth/@signin/SigninForm.tsx
@@ -26,6 +26,7 @@ const formStyles = {
   form: "flex w-full flex-col items-stretch justify-between gap-6 font-semibold text-gray-900",
 }
 
+// input에 표시될 요소를 객체로 정의
 const signinFormValue = [
   {
     label: "아이디",

--- a/src/components/pages/auth/@signup/SignupForm.tsx
+++ b/src/components/pages/auth/@signup/SignupForm.tsx
@@ -27,6 +27,7 @@ const formStyles = {
   form: "flex w-full flex-col items-stretch justify-between gap-6 font-semibold text-gray-900",
 }
 
+// input에 표시될 요소를 객체로 정의
 const signupFormValue = [
   {
     label: "이름",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
       "@public/*": ["./public/*"],
       "@mocks/*": ["./__mocks__/*"]
     },
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["jest"]
   },
   "include": [
     "postcss.config.mjs",
@@ -33,8 +34,7 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     "__mocks__/svgrMock.jsx",
-    "jest.setup.js",
-    "cypress.config.ts"
+    "jest.setup.js"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "cypress.config.ts", "cypress/**/*.tsx", "cypress"]
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #149

## 📝작업 내용

> -[x] auth 페이지의 레이아웃 디자인 수정
> -[x] auth 페이지의 페이지 조건부 렌더링 로직을 더 알맞게 수정
> -[x] jest와 cypress의 eslint 충돌을 해결
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 제가 알아보기로는 저만 입력하면 되는거 같긴 한데 만약 lint 에러가 발생한다면 아래 명령어를 한번 입력해주세요. eslint 캐시를 삭제하는 명령어입니다.

```bash
npm cache clean --force
npm install
```