### PR TITLE
#160 회원가입 e2e 테스트 로직 변경

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,7 +50,6 @@
     "React": "readonly"
   },
   "rules": {
-    "cypress/no-unnecessary-waiting": "off",
     // 긴 라인 줄바꿈 시 연산자 뒤에서 줄바꿈
     "operator-linebreak": "off",
     // 화살표 함수 사용 시 중괄호 포함시키도록

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,7 +1,20 @@
 import { defineConfig } from "cypress"
 
+const dotenv = require("dotenv")
+dotenv.config({ path: "./.env.local" })
+
 export default defineConfig({
   e2e: {
-    baseUrl: "http://localhost:3000",
+    baseUrl: process.env.TEST_URL,
+    setupNodeEvents(on, config) {
+      config.env = {
+        TEST_ID: process.env.TEST_ID,
+        TEST_PASSWORD: process.env.TEST_PASSWORD,
+        BACKEND_API: process.env.BASE_URL,
+        TEAM_ID: process.env.TEAM_ID,
+      }
+
+      return config
+    },
   },
 })

--- a/cypress/e2e/signup.cy.ts
+++ b/cypress/e2e/signup.cy.ts
@@ -48,39 +48,53 @@ describe("sign-up page test", () => {
   })
 
   it("should be disable to sign up with same email", () => {
+    const testId = Cypress.env("TEST_ID")
+    const testPassword = Cypress.env("TEST_PASSWORD")
     cy.get("#name").type("test")
     cy.get("#name").blur()
-    cy.get("#email").type("test10@test10.com")
+    cy.get("#email").type(testId)
     cy.get("#email").blur()
     cy.get("#companyName").type("test10")
     cy.get("#companyName").blur()
-    cy.get("#password").type("testtest")
+    cy.get("#password").type(testPassword)
     cy.get("#password").blur()
-    cy.get("#passwordConfirm").type("testtest")
+    cy.get("#passwordConfirm").type(testPassword)
     cy.get("#passwordConfirm").blur()
     cy.get(".group").should("be.enabled")
     cy.get(".group").click()
     cy.contains("이미 사용 중인").should("be.visible")
   })
 
-  // it("should be able to sign up", () => {
-  //   cy.get("#name").type("test")
-  //   cy.get("#name").blur()
-  //   cy.get("#email").type("test18@test18.com")
-  //   cy.get("#email").blur()
-  //   cy.get("#companyName").type("test18")
-  //   cy.get("#companyName").blur()
-  //   cy.get("#password").type("testtest")
-  //   cy.get("#password").blur()
-  //   cy.get("#passwordConfirm").type("testtest")
-  //   cy.get("#passwordConfirm").blur()
-  //   cy.get(".group").should("be.enabled")
-  //   cy.get(".group").click()
-  //   cy.contains("회원가입이 완료되었습니다.").should("be.visible")
-  // })
+  it("should be able to sign up", () => {
+    const testId = Cypress.env("TEST_ID")
+    const testPassword = Cypress.env("TEST_PASSWORD")
+    cy.intercept("POST", "**/auth?mode=signup", {
+      statusCode: 201,
+      body: {
+        message: "사용자 생성 성공",
+      },
+    }).as("signupRequest")
+    cy.get("#name").type("test")
+    cy.get("#name").blur()
+    cy.get("#email").type(testId)
+    cy.get("#email").blur()
+    cy.get("#companyName").type("test18")
+    cy.get("#companyName").blur()
+    cy.get("#password").type(testPassword)
+    cy.get("#password").blur()
+    cy.get("#passwordConfirm").type(testPassword)
+    cy.get("#passwordConfirm").blur()
+    cy.get(".group").should("be.enabled")
+    cy.get(".group").click()
+    cy.wait("@signupRequest").then((interception) => {
+      expect(interception.response?.statusCode).to.eq(201)
+    })
+    cy.contains("회원가입이 완료되었습니다.").should("be.visible")
+  })
 
   it("should be able to visit login page", () => {
     cy.contains("로그인").click()
     cy.location("pathname").should("contains", "/auth")
+    cy.url().should("include", "?mode=signin")
   })
 })

--- a/cypress/e2e/signup.cy.ts
+++ b/cypress/e2e/signup.cy.ts
@@ -90,6 +90,12 @@ describe("sign-up page test", () => {
       expect(interception.response?.statusCode).to.eq(201)
     })
     cy.contains("회원가입이 완료되었습니다.").should("be.visible")
+    cy.contains("확인").click()
+    cy.wait(1000)
+    // 회원가입 이후 cookie에 userToken 생성 후 마이페이지 접속 확인
+    cy.setCookie("userToken", "testToken")
+    cy.visit("/mypage")
+    cy.contains("마이페이지")
   })
 
   it("should be able to visit login page", () => {

--- a/cypress/e2e/signup.cy.ts
+++ b/cypress/e2e/signup.cy.ts
@@ -91,7 +91,6 @@ describe("sign-up page test", () => {
     })
     cy.contains("회원가입이 완료되었습니다.").should("be.visible")
     cy.contains("확인").click()
-    cy.wait(1000)
     // 회원가입 이후 cookie에 userToken 생성 후 마이페이지 접속 확인
     cy.setCookie("userToken", "testToken")
     cy.visit("/mypage")

--- a/cypress/e2e/wishlist.cy.ts
+++ b/cypress/e2e/wishlist.cy.ts
@@ -51,6 +51,8 @@ describe("add wish button test", () => {
 describe("wishlist page test", () => {
   beforeEach(() => {
     cy.intercept("POST", "/").as("goHome")
+    const testId = Cypress.env("TEST_ID")
+    const testPassword = Cypress.env("TEST_PASSWORD")
     cy.visit("/auth?mode=signin")
     cy.get("#email").type(testId)
     cy.get("#password").type(testPassword)

--- a/cypress/e2e/wishlist.cy.ts
+++ b/cypress/e2e/wishlist.cy.ts
@@ -48,11 +48,12 @@ describe("add wish button test", () => {
 
 describe("wishlist page test", () => {
   beforeEach(() => {
+    cy.intercept("POST", "/").as("goHome")
     cy.visit("/auth?mode=signin")
     cy.get("#email").type("test@test.com")
     cy.get("#password").type("testtest")
     cy.get(".group").click()
-    cy.wait(1000)
+    cy.wait("@goHome")
     cy.get('[href="/wishlist"]').click()
   })
   it("should access wishlist page", () => {

--- a/src/hooks/usePostSignup.ts
+++ b/src/hooks/usePostSignup.ts
@@ -8,14 +8,14 @@ const usePostSignup = () => {
     mutationFn: PostSignupFn,
     onSuccess: (data) => {
       // 성공적인 응답 처리
-      if ("code" in data) {
+      if (data && "code" in data) {
         // 에러 응답이 온 경우
         return Promise.reject(data)
       }
       return data
     },
     onError: (error) => {
-      if ("code" in error) {
+      if (error && "code" in error) {
         throw new Error(error.message)
       }
       throw error


### PR DESCRIPTION
## #️⃣연관된 이슈

> #160 

## 📝작업 내용

<br />
<img width="400" alt="스크린샷 2024-08-15 오후 8 28 40" src="https://github.com/user-attachments/assets/80493668-c813-420c-9169-234e4a844bc8">
<br />
<img width="400" alt="스크린샷 2024-08-15 오후 8 54 40" src="https://github.com/user-attachments/assets/5adec23e-6604-4065-86cc-037c7e8526cb">


- cy.intercept() 추가
- 응답 코드 추가
- 발견한 에러 수정
- cy.setCookie로 임의 쿠키 적용
- userToken 관련 미들웨어 동작 확인
- 마이페이지 접근 테스트 완료



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
<br />
<img width="200" alt="스크린샷 2024-08-15 오후 8 27 14" src="https://github.com/user-attachments/assets/b41487da-88dc-45ce-b7ec-50469ff2be8d">
<img width="200" alt="스크린샷 2024-08-15 오후 8 27 24" src="https://github.com/user-attachments/assets/64bd474f-a4ae-4b4b-8c50-e87f2b61cc6c">
<br />

- cypress 동작 확인 중 in 연산자 에러 발생을 확인했습니다.
- data가 undefined이나 in 연산자 작동으로 에러가 발생했습니다.
- mutation은 cypress에서 인식하지 못하고 해당 내용까지 바꿀 경우 test코드가 production 코드를 침법하는 것으로 보여 조건만 하나 추가했습니다.
